### PR TITLE
Checking for memcached extension

### DIFF
--- a/src/Atyagi/Elasticache/ElasticacheConnector.php
+++ b/src/Atyagi/Elasticache/ElasticacheConnector.php
@@ -13,6 +13,10 @@ class ElasticacheConnector {
      */
     public function connect(array $servers)
     {
+        if (!extension_loaded('memcached')) {
+            return false;
+        }
+        
         $memcached = $this->getMemcached();
 
         // Set Elasticache options here


### PR DESCRIPTION
Hi,

Firstly thanks for this package, it works great in production for me,

I have an issue where on my local environment which is Windows I get a 'Class Memcached Not Found'. This breaks the entire application as the error occurs in the service provider. It's not possible to install the Memcached.dll extension on Windows but as I am not using the memcached driver in this environment (it's set to file) I don't want my application to fall over due to a missing driver that I'm not using.

I've patched this bug with the following simple check to test for the extension. There might be a better way of doing it but this works for me!